### PR TITLE
Add quotes to jsonpath in elasticsearch tutorial

### DIFF
--- a/docs/tutorials/elasticsearch.md
+++ b/docs/tutorials/elasticsearch.md
@@ -148,7 +148,7 @@ $ kubectl get pods e1-0 -n demo -o yaml | grep IP
   podIP: 172.17.0.5
 
 # Exec into kubedb operator pod
-$ kubectl exec -it $(kubectl get pods --all-namespaces -l app=kubedb -o jsonpath={.items[0].metadata.name}) -n kube-system sh
+$ kubectl exec -it $(kubectl get pods --all-namespaces -l app=kubedb -o jsonpath='{.items[0].metadata.name}') -n kube-system sh
 
 ~ $ ps aux
 PID   USER     TIME   COMMAND


### PR DESCRIPTION
Some shells (zsh, in my case) use curly braces for pattern expansion differently than sh/bash, so provided command fails:

```
$ kubectl exec -it $(kubectl get pods --all-namespaces -l app=kubedb -o jsonpath={.items[0].metadata.name}) -n kube-system sh

zsh: no matches found: jsonpath={.items[0].metadata.name}
error: expected 'exec POD_NAME COMMAND [ARG1] [ARG2] ... [ARGN]'.
POD_NAME and COMMAND are required arguments for the exec command
See 'kubectl exec -h' for help and examples.
```

I've added quotes to aviod that.